### PR TITLE
feat: Replace ID generation with a secure method using crypto.randomUUID

### DIFF
--- a/frontend/src/components/FlowEditor.tsx
+++ b/frontend/src/components/FlowEditor.tsx
@@ -57,8 +57,14 @@ const STATUS_POLL_INTERVAL_FAST = 600;
 const STATUS_POLL_INTERVAL_WAITING = 450;
 const STATUS_POLL_INTERVAL_ERROR = 4000;
 
-let id = 0;
-const getId = () => `dnd_${id++}`;
+let fallbackCounter = 0;
+const createNodeId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  fallbackCounter += 1;
+  return `node_${Date.now().toString(36)}_${fallbackCounter}`;
+};
 
 type DragMetaPayload = {
   tone?: unknown;
@@ -455,7 +461,7 @@ function EditorInner() {
           : undefined;
       const artifactPorts = metaPorts ?? templatePorts;
 
-      const newNodeId = getId();
+      const newNodeId = createNodeId();
       const newNode: Node<FlowNodeData> = {
         id: newNodeId,
         type,


### PR DESCRIPTION
Fix issue #24 

This pull request updates the way node IDs are generated in the `FlowEditor.tsx` component to ensure uniqueness and improve robustness. The main change is the replacement of the old incremental ID generator with a new function that uses `crypto.randomUUID()` when available, falling back to a timestamp-based approach if necessary.

**Node ID generation improvements:**

* Replaced the old `getId` function, which generated IDs like `dnd_0`, `dnd_1`, etc., with a new `createNodeId` function that uses `crypto.randomUUID()` for unique IDs, and falls back to a timestamp and counter if `crypto` is unavailable. (`frontend/src/components/FlowEditor.tsx`)
* Updated all usages of the old `getId` function to use the new `createNodeId` function, ensuring all new nodes receive robust, unique IDs. (`frontend/src/components/FlowEditor.tsx`) 