### PR TITLE
feat: standardize node runtime status on Argo Server API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import subprocess
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -236,16 +237,13 @@ class WorkflowLogsResponse(BaseModel):
     logs: str
 
 
-app = FastAPI(title="Synthetic Data Suite Backend", version="0.1.0")
-app.include_router(component_generation_router)
-
-
-@app.on_event("startup")
-def _startup_registry() -> None:
+@asynccontextmanager
+async def lifespan(_: FastAPI):
     try:
         engine = get_engine()
     except RuntimeError as exc:
         logger.error("Database not configured: %s", exc)
+        yield
         return
 
     if should_run_migrations():
@@ -260,6 +258,12 @@ def _startup_registry() -> None:
             _ = ComponentRegistry(session)
     except Exception as exc:
         logger.warning("Failed to initialize component registry: %s", exc)
+
+    yield
+
+
+app = FastAPI(title="Synthetic Data Suite Backend", version="0.1.0", lifespan=lifespan)
+app.include_router(component_generation_router)
 
 
 # Allow CORS in dev so the frontend can call the API easily

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "kubernetes>=28.1.0",
     "minio>=7.2.18",
     "pydantic>=2.12.3",
+    "pytest>=8.0.0",
     "python-multipart>=0.0.20",
     "python-dotenv>=1.0.1",
     "pyyaml>=6.0.3",

--- a/backend/tests/test_workflow_status.py
+++ b/backend/tests/test_workflow_status.py
@@ -1,0 +1,88 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402
+
+
+def test_workflow_status_maps_nodes_and_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "status": {
+            "phase": "Succeeded",
+            "startedAt": "2024-01-01T00:01:00Z",
+            "nodes": {
+                "node-1": {
+                    "displayName": "task-a",
+                    "phase": "Succeeded",
+                    "type": "Pod",
+                    "id": "123",
+                    "message": "ok",
+                    "progress": "1/1",
+                    "startedAt": "2024-01-01T00:01:10Z",
+                    "finishedAt": "2024-01-01T00:01:20Z",
+                },
+                "node-2": {
+                    "name": "task-b",
+                    "phase": "Running",
+                    "type": "Pod",
+                    "id": "456",
+                },
+            },
+        }
+    }
+
+    class StubArgoClient:
+        def get_workflow(self, namespace: str, workflow_name: str):
+            assert namespace == "test-ns"
+            assert workflow_name == "wf-1"
+            return payload
+
+    monkeypatch.setattr(main, "ArgoClient", lambda: StubArgoClient())
+
+    response = main.get_workflow_status(workflow_name="wf-1", namespace="test-ns")
+
+    assert response.workflow_name == "wf-1"
+    assert response.namespace == "test-ns"
+    assert response.phase == "Succeeded"
+    assert response.finished is True
+    assert response.updated_at == "2024-01-01T00:01:00Z"
+
+    assert "task-a" in response.nodes
+    assert response.nodes["task-a"].slug == "task-a"
+    assert response.nodes["task-a"].phase == "Succeeded"
+    assert response.nodes["task-a"].display_name == "task-a"
+
+    assert "task-b" in response.nodes
+    assert response.nodes["task-b"].slug == "task-b"
+    assert response.nodes["task-b"].phase == "Running"
+    assert response.nodes["task-b"].display_name == "task-b"
+
+
+def test_workflow_status_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubArgoClient:
+        def get_workflow(self, namespace: str, workflow_name: str):
+            raise main.ArgoNotFoundError("not found")
+
+    monkeypatch.setattr(main, "ArgoClient", lambda: StubArgoClient())
+
+    with pytest.raises(HTTPException) as excinfo:
+        main.get_workflow_status(workflow_name="wf-404", namespace="test-ns")
+
+    assert excinfo.value.status_code == 404
+
+
+def test_workflow_status_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubArgoClient:
+        def get_workflow(self, namespace: str, workflow_name: str):
+            raise main.ArgoClientError("bad gateway")
+
+    monkeypatch.setattr(main, "ArgoClient", lambda: StubArgoClient())
+
+    with pytest.raises(HTTPException) as excinfo:
+        main.get_workflow_status(workflow_name="wf-500", namespace="test-ns")
+
+    assert excinfo.value.status_code == 502

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -321,6 +321,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -559,6 +568,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -726,6 +744,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
     { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
     { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -917,6 +960,7 @@ dependencies = [
     { name = "minio" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
+    { name = "pytest" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -933,6 +977,7 @@ requires-dist = [
     { name = "minio", specifier = ">=7.2.18" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },

--- a/backend/workflow_builder.py
+++ b/backend/workflow_builder.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import os
 
 import yaml
-from pydantic import BaseModel, Field  # type: ignore[import-not-found]
+from pydantic import BaseModel, ConfigDict, Field  # type: ignore[import-not-found]
 
 logger = logging.getLogger(__name__)
 
@@ -79,12 +79,11 @@ class FlowEdgePayload(BaseModel):
 
 
 class WorkflowGraphPayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     session_id: str = Field(..., alias="sessionId")
     nodes: List[FlowNodePayload]
     edges: List[FlowEdgePayload]
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 class ArtifactPlan(BaseModel):

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -164,6 +164,8 @@ Además, el backend ejecuta directamente `argo submit` usando el manifiesto gene
 
 La respuesta del endpoint incluye el nombre del workflow lanzado, el namespace y la ruta dentro de MinIO donde se guardó el YAML (`sessions/<sessionId>/workflow/<filename>`), para poder consultarlo más adelante si es necesario.
 
+> **Nota:** Estas variables sólo aplican al envío de workflows; el seguimiento de estado usa la API de Argo Server y no depende del binario `argo`.
+
 ### Enviar el DAG generado en el canvas
 
 El editor (`frontend`) envía el flujo directamente a Argo usando el botón **Enviar Workflow**. El proceso es:
@@ -205,4 +207,3 @@ El frontend realiza polling periódico contra `GET /workflow/status`. Si el serv
 - Si Argo pide login, espera a que el `k8s-up.sh` haya aplicado el parche `--auth-mode=server` y que el rollout termine.
 - Si un port-forward no arranca, revisa logs en `.tmp/dev/*.log`.
 - Si cambias los manifests en `deploy/`, vuelve a correr `make k8s-up` o aplica los YAML con `kubectl apply -f ...`.
-


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the backend, focusing on FastAPI application lifecycle management, testing, and minor dependency and documentation updates. The most significant change is refactoring the FastAPI app startup logic to use the new lifespan protocol, which improves maintainability and aligns with FastAPI best practices. Additionally, the pull request adds a new test suite for workflow status handling and makes minor dependency and documentation updates.

**FastAPI application lifecycle and configuration:**

* Refactored FastAPI app initialization to use the `lifespan` protocol (via `@asynccontextmanager`) instead of the deprecated `@app.on_event("startup")`, improving startup/shutdown handling and code clarity (`backend/main.py`). [[1]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903R6) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L239-R246) [[3]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903R262-R267)

**Testing:**

* Added a new test module `test_workflow_status.py` with tests for workflow status mapping, not found, and API error scenarios, increasing test coverage and reliability of workflow status endpoints (`backend/tests/test_workflow_status.py`).

**Dependencies:**

* Added `pytest` as a dependency in `pyproject.toml` to support the new and future tests (`backend/pyproject.toml`).

**Pydantic model configuration:**

* Updated `WorkflowGraphPayload` to use the new `ConfigDict` for `populate_by_name` instead of the legacy `Config` class, aligning with Pydantic v2 conventions (`backend/workflow_builder.py`). [[1]](diffhunk://#diff-5026ad17d8108c9e1cbc2760ce067ed066863f72358aad445430a8b1e91fafdeL15-R15) [[2]](diffhunk://#diff-5026ad17d8108c9e1cbc2760ce067ed066863f72358aad445430a8b1e91fafdeR82-L88)

**Documentation:**

* Clarified in `dev-workflow.md` that workflow status tracking uses the Argo Server API and does not depend on the `argo` CLI binary, and made minor formatting adjustments (`docs/dev-workflow.md`). [[1]](diffhunk://#diff-15f3592d84a293081f0b75ae897876848d6b5cf177af36d8aae0c230161e165fR167-R168) [[2]](diffhunk://#diff-15f3592d84a293081f0b75ae897876848d6b5cf177af36d8aae0c230161e165fL208)