### PR TITLE
feat: allow configuring the local Postgres port via DB_LOCAL_PORT

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -28,7 +28,7 @@ Antes de empezar, asegúrate de tener instalados:
 ```bash
 make dev
 ```
-Arranca: MinIO + Argo + Postgres en minikube, abre los puertos (9090/9000 para MinIO, 2746 para Argo, 5432 para DB) y lanza frontend (3000) y backend (8000).
+Arranca: MinIO + Argo + Postgres en minikube, abre los puertos (9090/9000 para MinIO, 2746 para Argo, `5432` para DB por defecto o `DB_LOCAL_PORT`) y lanza frontend (3000) y backend (8000).
 
 ---
 
@@ -111,7 +111,7 @@ make workflow            # envía workflow de ejemplo a Argo
 - MinIO API: `http://localhost:9000`
 - MinIO Console: `http://localhost:9090`
 - Argo UI: `https://localhost:2746`
-- Postgres: `localhost:5432`
+- Postgres: `localhost:5432` (o `localhost:$DB_LOCAL_PORT` si defines `DB_LOCAL_PORT`)
 - Frontend: `http://localhost:3000`
 - Backend: `http://localhost:8000`
 
@@ -120,6 +120,7 @@ make workflow            # envía workflow de ejemplo a Argo
 ### Variables útiles
 - `MINIKUBE_PROFILE` — perfil de minikube (por defecto `minikube`)
 - `K8S_CONTEXT` — contexto de kubectl (por defecto `minikube`)
+- `DB_LOCAL_PORT` — puerto local para el port-forward de Postgres (por defecto `5432`)
 - `DATABASE_URL` — conexión a Postgres (ej. `postgresql+psycopg://syntheticdata:syntheticdata@localhost:5432/syntheticdata`)
 - `RUN_MIGRATIONS` — crea tablas del registry al iniciar (`true`/`false`)
 

--- a/scripts/dev/port-forward.sh
+++ b/scripts/dev/port-forward.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 #   scripts/dev/port-forward.sh start [--only minio|argo|db]
 #   scripts/dev/port-forward.sh stop  [--only minio|argo|db]
 #   scripts/dev/port-forward.sh status
+#
+# Environment variables:
+#   DB_LOCAL_PORT   Local TCP port used for Postgres port-forward (default: 5432)
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STATE_DIR="$ROOT_DIR/.tmp/dev"
@@ -43,6 +46,8 @@ should_do() {
   if [[ -z "$ONLY_COMPONENT" ]]; then return 0; fi
   [[ "$ONLY_COMPONENT" == "$comp" ]]
 }
+
+DB_LOCAL_PORT="${DB_LOCAL_PORT:-5432}"
 
 start_pf() {
   local name="$1" namespace="$2" resource="$3" ports="$4"
@@ -95,7 +100,13 @@ case "$ACTION" in
   start)
     if should_do minio; then start_pf minio minio-dev pod/minio "9000:9000 9090:9090"; fi
     if should_do argo;  then start_pf argo  argo      deployment/argo-server "2746:2746"; fi
-    if should_do db;    then start_pf db    syntheticdata statefulset/postgres "5432:5432"; fi
+    if should_do db; then
+      if ! [[ "$DB_LOCAL_PORT" =~ ^[0-9]+$ ]] || (( DB_LOCAL_PORT < 1 || DB_LOCAL_PORT > 65535 )); then
+        echo "[pf][error] DB_LOCAL_PORT inválido: '$DB_LOCAL_PORT' (usa 1-65535)." >&2
+        exit 1
+      fi
+      start_pf db syntheticdata statefulset/postgres "${DB_LOCAL_PORT}:5432"
+    fi
     ;;
   stop)
     if should_do minio; then stop_pf minio; fi
@@ -110,5 +121,3 @@ case "$ACTION" in
     exit 1
     ;;
 esac
-
-

--- a/scripts/dev/start-stack.sh
+++ b/scripts/dev/start-stack.sh
@@ -65,8 +65,15 @@ if [[ "$DO_BACKEND" -eq 1 ]]; then
   export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
   export MINIO_SECURE="${MINIO_SECURE:-0}"
 
+  # Puerto local para Postgres en dev (port-forward). Default: 5432.
+  DB_LOCAL_PORT="${DB_LOCAL_PORT:-5432}"
+  if ! [[ "$DB_LOCAL_PORT" =~ ^[0-9]+$ ]] || (( DB_LOCAL_PORT < 1 || DB_LOCAL_PORT > 65535 )); then
+    echo "[stack][error] DB_LOCAL_PORT inválido: '$DB_LOCAL_PORT' (usa 1-65535)." >&2
+    exit 1
+  fi
+
   # DB (Postgres) defaults for local dev via port-forward
-  export DATABASE_URL="${DATABASE_URL:-postgresql+psycopg://syntheticdata:syntheticdata@localhost:5432/syntheticdata}"
+  export DATABASE_URL="${DATABASE_URL:-postgresql+psycopg://syntheticdata:syntheticdata@localhost:${DB_LOCAL_PORT}/syntheticdata}"
   export RUN_MIGRATIONS="${RUN_MIGRATIONS:-true}"
 
   # Sync de dependencias desde pyproject/uv.lock y lanzamiento con uv
@@ -99,5 +106,4 @@ else
   # Mantener el script vivo para que el trap pueda cerrar PF si es necesario
   while true; do sleep 3600; done
 fi
-
 


### PR DESCRIPTION
This pull request introduces support for customizing the local port used for Postgres port-forwarding in the development workflow. It allows developers to specify the `DB_LOCAL_PORT` environment variable to avoid port conflicts, and updates relevant scripts and documentation to reflect this new flexibility. Validation is added to ensure the port value is within a valid range.

**Development workflow improvements:**

* Added support for the `DB_LOCAL_PORT` environment variable to customize the local TCP port used for Postgres port-forwarding in `scripts/dev/port-forward.sh` and `scripts/dev/start-stack.sh`, with input validation to ensure the port is a valid integer between 1 and 65535. [[1]](diffhunk://#diff-55b9ff91cea512f3ded3a8a00fdbe203764d1ef020d6e075cb3628193f33fd82R9-R11) [[2]](diffhunk://#diff-55b9ff91cea512f3ded3a8a00fdbe203764d1ef020d6e075cb3628193f33fd82R50-R51) [[3]](diffhunk://#diff-55b9ff91cea512f3ded3a8a00fdbe203764d1ef020d6e075cb3628193f33fd82L98-R109) [[4]](diffhunk://#diff-2e92da8902636fcb4b41805c3a11c97db92c7a45c32be6b1629b2e20ab6fe3b3R68-R76)

**Documentation updates:**

* Updated `docs/dev-workflow.md` to document the new `DB_LOCAL_PORT` variable, its default value, and how it affects the local Postgres port in both instructions and example URLs. [[1]](diffhunk://#diff-15f3592d84a293081f0b75ae897876848d6b5cf177af36d8aae0c230161e165fL31-R31) [[2]](diffhunk://#diff-15f3592d84a293081f0b75ae897876848d6b5cf177af36d8aae0c230161e165fL114-R114) [[3]](diffhunk://#diff-15f3592d84a293081f0b75ae897876848d6b5cf177af36d8aae0c230161e165fR123)

**Environment configuration:**

* Modified the construction of `DATABASE_URL` in `scripts/dev/start-stack.sh` to use the value of `DB_LOCAL_PORT` instead of the hardcoded `5432`.

These changes make it easier to run multiple development environments simultaneously or avoid conflicts with other local Postgres instances.

This changes solve issue #31 